### PR TITLE
Support sizing for jfrog platform

### DIFF
--- a/6.artifactory-aws-install/README.md
+++ b/6.artifactory-aws-install/README.md
@@ -3,7 +3,7 @@ This example will prepare the AWS infrastructure and services required to run [J
 1. The AWS VPC
 2. RDS (PostgreSQL) as the database
 2. S3 as the object storage
-3. EKS as the Kubernetes cluster running Artifactory
+3. EKS as the Kubernetes cluster for running Artifactory
 
 The resources are split between individual files for easy and clear separation.
 
@@ -52,4 +52,20 @@ terraform destroy
 To get the `kubectl` configuration for the EKS cluster, run the following command
 ```shell
 aws eks --region $(terraform output -raw region) update-kubeconfig --name $(terraform output -raw cluster_name)
+```
+
+### Install Artifactory
+Once done, install Artifactory using the Helm Chart with the following command.
+
+Terraform will create the needed configuration files to be used for the `helm install` command.
+This command will auto generate and be writen to the console when you run the `Terraform apply` command.
+```shell
+helm upgrade --install artifactory jfrog/artifactory \
+  --version <version> \
+  --namespace <namespace> --create-namespace \
+  -f artifactory-values.yaml \
+  -f artifactory-license.yaml \
+  -f artifactory/sizing/artifactory-<sizing>.yaml \
+  -f artifactory-custom.yaml \
+  --timeout 600s
 ```

--- a/6.artifactory-aws-install/rds.tf
+++ b/6.artifactory-aws-install/rds.tf
@@ -23,7 +23,7 @@ resource "aws_db_instance" "artifactory_db" {
       var.artifactory_rds_size_default
   )
 
-  storage_type      = "gp3"        # Using gp3 for storage type
+  storage_type      = "gp3"
   allocated_storage = (
       var.sizing == "medium"  ? "250" :
       var.sizing == "large"   ? "500" :

--- a/7.jfrog-platform-aws-install/README.md
+++ b/7.jfrog-platform-aws-install/README.md
@@ -59,12 +59,12 @@ Terraform will create the needed configuration files to be used for the `helm in
 This command will auto generate and be writen to the console when you run the `Terraform apply` command.
 ```shell
 helm upgrade --install jfrog jfrog/jfrog-platform \
-  --version 10.20.1 \
-  --namespace jfrog --create-namespace \
+  --version <version> \
+  --namespace <namesapce>> --create-namespace \
   -f ./jfrog-values.yaml \
   -f ./artifactory-license.yaml \
-  -f ./jfrog-artifactory-small-adjusted.yaml \
-  -f ./jfrog-xray-small-adjusted.yaml \
+  -f ./jfrog-artifactory-<sizing>-adjusted.yaml \
+  -f ./jfrog-xray--<sizing>-adjusted.yaml \
   -f ./jfrog-custom.yaml \
   --timeout 600s
 ```

--- a/7.jfrog-platform-aws-install/README.md
+++ b/7.jfrog-platform-aws-install/README.md
@@ -1,12 +1,30 @@
-### JFrog Platform Installation in AWS with Terraform
-This example will install Artifactory and Xray (with the [jfrog-platform helm chart](https://github.com/jfrog/charts/tree/master/stable/jfrog-platform)) in AWS using Terraform. The Artifactory and Xray installations will use the AWS services
-1. RDS (PostgreSQL) as the database for each application
+# JFrog Platform Installation in AWS with Terraform
+This example will prepare the AWS infrastructure and services required to run Artifactory and Xray (installed with the [jfrog-platform Helm Chart](https://github.com/jfrog/charts/tree/master/stable/jfrog-platform)) using Terraform:
+1. The AWS VPC
+2. RDS (PostgreSQL) as the database for each application
 2. S3 as the Artifactory object storage
-3. EKS as the Kubernetes cluster running Artifactory and Xray with pre-defined node groups for the different services
+3. EKS as the Kubernetes cluster for running Artifactory and Xray with pre-defined node groups for the different services
 
 The resources are split between individual files for easy and clear separation.
 
+
+## Prepare the JFrog Platform Configurations
 The [jfrog-values.yaml](jfrog-values.yaml) file has the values that Helm will use to configure the JFrog Platform installation.
+
+The [artifactory-license-template.yaml](artifactory-license-template.yaml) file has the license key(s) template that you will need to copy to a `artifactory-license.yaml` file.
+```shell
+cp artifactory-license-template.yaml artifactory-license.yaml
+```
+
+If you plan on skipping the license key(s) for now, you can leave the `artifactory-license.yaml` file empty. Terraform will create an empty one for you if you don't create it.
+
+## JFrog Platform Sizing
+Artifactory and Xray have pre-defined sizing templates that you can use to deploy them. The supported sizing templates in this project are `small`, `medium`, `large`, `xlarge`, and `2xlarge`.
+
+The sizing templates will be pulled from the [official Helm Charts](https://github.com/jfrog/charts) during the execution of the Terraform configuration.
+
+## Terraform
+
 
 1. Initialize the Terraform configuration by running the following command
 ```shell
@@ -15,12 +33,12 @@ terraform init
 
 2. Plan the Terraform configuration by running the following command
 ```shell
-terraform plan
+terraform plan -var 'sizing=small'
 ```
 
 3. Apply the Terraform configuration by running the following command
 ```shell
-terraform apply
+terraform apply -var 'sizing=small'
 ```
 
 4. When you are done, you can destroy the resources by running the following command
@@ -32,4 +50,21 @@ terraform destroy
 To get the `kubectl` configuration for the EKS cluster, run the following command
 ```shell
 aws eks --region $(terraform output -raw region) update-kubeconfig --name $(terraform output -raw cluster_name)
+```
+
+### Install JFrog Platform
+Once done, install the JFrog Platform (Artifactory and Xray) using the Helm Chart with the following command.
+
+Terraform will create the needed configuration files to be used for the `helm install` command.
+This command will auto generate and be writen to the console when you run the `Terraform apply` command.
+```shell
+helm upgrade --install jfrog jfrog/jfrog-platform \
+  --version 10.20.1 \
+  --namespace jfrog --create-namespace \
+  -f ./jfrog-values.yaml \
+  -f ./artifactory-license.yaml \
+  -f ./jfrog-artifactory-small-adjusted.yaml \
+  -f ./jfrog-xray-small-adjusted.yaml \
+  -f ./jfrog-custom.yaml \
+  --timeout 600s
 ```

--- a/7.jfrog-platform-aws-install/artifactory-license-template.yaml
+++ b/7.jfrog-platform-aws-install/artifactory-license-template.yaml
@@ -1,0 +1,11 @@
+## A template for the Artifactory license as a helm value.
+## Copy this file to artifactory-license.yaml and fill in the full license key(s).
+artifactory:
+  artifactory:
+    license:
+      licenseKey: |
+        cHJvZHVjdHM6CiAgYXJ1aWZhY3Rvcnk6CiAgICBwcm9kdWN0OiBaWGh3YVhKbGN6b2dNakF5TlMx
+        TFRGaFpXTmlNRGs1T0dRMVpncHZkMjVsY2p...
+        
+        cHJvZHVjdHM6CiAgYXJ0aWZhY3Rvcnk6CiAgIBBwcm9kdWN0OiBaWGh3YVhKbGN6b2dNakF5TlMv
+        d05DMHdObFF5TURvMU9UbzFPVm9LYVdRNkl...

--- a/7.jfrog-platform-aws-install/eks.tf
+++ b/7.jfrog-platform-aws-install/eks.tf
@@ -61,11 +61,22 @@ module "eks" {
         artifactory = {
             name = "artifactory-node-group"
 
-            instance_types = ["m7g.large"]
+            instance_types = [(
+                var.sizing == "large"   ? var.artifactory_node_size_large :
+                var.sizing == "xlarge"  ? var.artifactory_node_size_large :
+                var.sizing == "2xlarge" ? var.artifactory_node_size_large :
+                var.artifactory_node_size_default
+            )]
 
             min_size     = 1
-            max_size     = 3
-            desired_size = 1
+            max_size     = 10
+            desired_size = (
+                var.sizing == "medium"  ? 2 :
+                var.sizing == "large"   ? 3 :
+                var.sizing == "xlarge"  ? 4 :
+                var.sizing == "2xlarge" ? 6 :
+                1
+            )
 
             labels = {
                 "group" = "artifactory"
@@ -75,11 +86,21 @@ module "eks" {
         nginx = {
             name = "nginx-node-group"
 
-            instance_types = ["c7g.large"]
+            instance_types = [(
+                var.sizing == "xlarge"  ? var.nginx_node_size_large :
+                var.sizing == "2xlarge" ? var.nginx_node_size_large :
+                var.nginx_node_size_default
+            )]
 
             min_size     = 1
-            max_size     = 2
-            desired_size = 1
+            max_size     = 10
+            desired_size = (
+                var.sizing == "medium"  ? 2 :
+                var.sizing == "large"   ? 2 :
+                var.sizing == "xlarge"  ? 2 :
+                var.sizing == "2xlarge" ? 3 :
+                1
+            )
 
             labels = {
                 "group" = "nginx"
@@ -89,7 +110,11 @@ module "eks" {
         xray = {
             name = "xray-node-group"
 
-            instance_types = ["c7g.large"]
+            instance_types = [(
+                var.sizing == "xlarge"  ? var.xray_node_size_xlarge :
+                var.sizing == "2xlarge" ? var.xray_node_size_xlarge :
+                var.xray_node_size_default
+            )]
 
             min_size     = 1
             max_size     = 4
@@ -97,6 +122,21 @@ module "eks" {
 
             labels = {
                 "group" = "xray"
+            }
+        }
+
+        ## Create an extra node group for testing
+        extra = {
+            name = "extra-node-group"
+
+            instance_types = [var.nginx_node_size_default]
+
+            min_size     = 1
+            max_size     = 3
+            desired_size = 3
+
+            labels = {
+                "group" = "extra"
             }
         }
     }

--- a/7.jfrog-platform-aws-install/jfrog-platform.tf
+++ b/7.jfrog-platform-aws-install/jfrog-platform.tf
@@ -16,12 +16,18 @@ provider "kubernetes" {
 # Fetch the Artifactory Helm chart and untar it to the current directory so helm install can use the sizing files
 resource "null_resource" "fetch_artifactory_chart" {
   provisioner "local-exec" {
+    command = "rm -rf artifactory-*.tgz"
+  }
+  provisioner "local-exec" {
     command = "helm fetch artifactory --version ${var.artifactory_chart_version} --repo https://charts.jfrog.io --untar"
   }
 }
 
 # Fetch the Xray Helm chart and untar it to the current directory so helm install can use the sizing files
 resource "null_resource" "fetch_xray_chart" {
+  provisioner "local-exec" {
+    command = "rm -rf xray-*.tgz"
+  }
   provisioner "local-exec" {
     command = "helm fetch xray --version ${var.xray_chart_version} --repo https://charts.jfrog.io --untar"
   }

--- a/7.jfrog-platform-aws-install/jfrog-values.yaml
+++ b/7.jfrog-platform-aws-install/jfrog-values.yaml
@@ -18,6 +18,11 @@ postgresql:
 artifactory:
   artifactory:
 
+    ## To provide support for HA
+    extraEnvironmentVariables:
+      - name : JF_SHARED_NODE_HAENABLED
+        value: "true"
+
     ## Artifactory to use S3 for filestore
     persistence:
       enabled: false
@@ -44,7 +49,7 @@ artifactory:
   nginx:
     disableProxyBuffering: true
 
-    ## Logs options
+    ## Logs to stdout and stderr
     logs:
       stderr: true
       stdout: true
@@ -53,6 +58,134 @@ artifactory:
     ## Run on nodes marked with the label "group=nginx"
     nodeSelector:
       group: "nginx"
+
+    service:
+      ## Use an NLB for the Nginx service for better performance
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+        service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "instance"
+        service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+        service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: "TCP"
+        service.beta.kubernetes.io/aws-load-balancer-healthcheck-port: "traffic-port"
+
+    ## Custom Nginx configuration for better performance
+    mainConf: |
+      # Main Nginx configuration file
+      worker_processes  auto;
+      error_log  stderr warn;
+      pid        /var/run/nginx.pid;
+      
+      events {
+        worker_connections  8192;
+        multi_accept on;
+        use epoll;
+      }
+      
+      http {
+        include       /etc/nginx/mime.types;
+        default_type  application/octet-stream;
+      
+        variables_hash_max_size 1024;
+        variables_hash_bucket_size 64;
+        server_names_hash_max_size 4096;
+        server_names_hash_bucket_size 128;
+        types_hash_max_size 2048;
+        types_hash_bucket_size 64;
+        proxy_read_timeout 2400s;
+        client_header_timeout 2400s;
+        client_body_timeout 2400s;
+        proxy_connect_timeout 75s;
+        proxy_send_timeout 2400s;
+        proxy_buffer_size 128k;
+        proxy_buffers 40 128k;
+        proxy_busy_buffers_size 128k;
+        proxy_temp_file_write_size 250m;
+        proxy_http_version 1.1;
+        client_body_buffer_size 128k;
+      
+        log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+        '$status $body_bytes_sent "$http_referer" '
+        '"$http_user_agent" "$http_x_forwarded_for"';
+      
+        log_format timing 'ip = $remote_addr '
+        'user = \"$remote_user\" '
+        'local_time = \"$time_local\" '
+        'host = $host '
+        'request = \"$request\" '
+        'status = $status '
+        'bytes = $body_bytes_sent '
+        'upstream = \"$upstream_addr\" '
+        'upstream_time = $upstream_response_time '
+        'request_time = $request_time '
+        'referer = \"$http_referer\" '
+        'UA = \"$http_user_agent\"';
+        access_log /dev/stdout timing;
+      
+        sendfile        on;
+        #tcp_nopush     on;
+      
+        keepalive_timeout  65;
+      
+        #gzip  on;
+      
+        include /etc/nginx/conf.d/*.conf;
+      }
+  
+
+    artifactoryConf: |
+      ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+      ssl_certificate  /var/opt/jfrog/nginx/ssl/tls.crt;
+      ssl_certificate_key  /var/opt/jfrog/nginx/ssl/tls.key;
+      ssl_session_cache shared:SSL:1m;
+      ssl_prefer_server_ciphers   on;
+      
+      upstream artifactory {
+         server jfrog-artifactory:8082;
+         keepalive 1000;
+         keepalive_requests 10000;
+      }
+      
+      ## server configuration
+      server {
+        listen 8443 ssl;
+        listen 8080;
+        server_name ~(?<repo>.+)\.artifactory artifactory;  
+      
+        if ($http_x_forwarded_proto = '') {
+          set $http_x_forwarded_proto  $scheme;
+        }
+        set $host_port 443;
+        if ( $scheme = "http" ) {
+          set $host_port 80;
+        }
+        ## Application specific logs
+        ## access_log /var/log/nginx/artifactory-access.log timing;
+        ## error_log /var/log/nginx/artifactory-error.log;
+        rewrite ^/artifactory/?$ / redirect;
+        if ( $repo != "" ) {
+          rewrite ^/(v1|v2)/(.*) /artifactory/api/docker/$repo/$1/$2 break;
+        }
+        chunked_transfer_encoding on;
+        client_max_body_size 0;
+      
+        location / {
+           proxy_read_timeout  900;
+           proxy_pass_header   Server;
+           proxy_cookie_path   ~*^/.* /;
+           proxy_pass          http://artifactory;
+           proxy_set_header    Connection "";
+           proxy_set_header    X-JFrog-Override-Base-Url $http_x_forwarded_proto://$host;
+           proxy_set_header    X-Forwarded-Port  $server_port;
+           proxy_set_header    X-Forwarded-Proto $http_x_forwarded_proto;
+           proxy_set_header    Host              $http_host;
+           proxy_set_header    X-Forwarded-For   $proxy_add_x_forwarded_for;
+           proxy_http_version 1.1;
+           proxy_request_buffering off;
+           proxy_buffering off;
+           add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        }
+      }
+
 
   ## Don't use the PostgreSQL chart
   postgresql:
@@ -78,6 +211,11 @@ xray:
   global:
     nodeSelector:
       group: "xray"
+
+#  observability:
+#    extraEnvVars: |
+#      - name: JF_DUMMY
+#        value: "true"
 
 # RabbitMQ is required for Xray
 rabbitmq:

--- a/7.jfrog-platform-aws-install/metrics.tf
+++ b/7.jfrog-platform-aws-install/metrics.tf
@@ -1,3 +1,11 @@
+provider "helm" {
+  kubernetes {
+    host                   = module.eks.cluster_endpoint
+    token                  = data.aws_eks_cluster_auth.jfrog_cluster.token
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  }
+}
+
 # Install the metrics server
 resource "helm_release" "metrics_server" {
   name       = "metrics-server"

--- a/7.jfrog-platform-aws-install/outputs.tf
+++ b/7.jfrog-platform-aws-install/outputs.tf
@@ -24,7 +24,10 @@ output "_05_setting_cluster_kubectl_context" {
   value       = "aws eks --region ${var.region} update-kubeconfig --name ${module.eks.cluster_name}"
 }
 
-output "_06_artifactory_url" {
-  description = "The URL of the load balancer for Artifactory"
-  value = "https://${data.kubernetes_resources.nginx_service.objects[0].status.loadBalancer.ingress[0].hostname}"
+# Output the command to install Artifactory with Helm
+# TODO: Fix Xray sizing breaking the template
+output "_06_jfrog_platform_install_command" {
+  description = "The Helm command to install the JFrog Platform (after setting up kubectl context)"
+  # value       = "helm upgrade --install jfrog jfrog/jfrog-platform --version ${var.jfrog_platform_chart_version} --namespace ${var.namespace} --create-namespace -f ${path.module}/jfrog-values.yaml -f ${path.module}/artifactory-license.yaml -f ${path.module}/jfrog-artifactory-${var.sizing}-adjusted.yaml -f ${path.module}/jfrog-xray-${var.sizing}-adjusted.yaml -f ${path.module}/jfrog-custom.yaml --timeout 600s"
+  value       = "helm upgrade --install jfrog jfrog/jfrog-platform --version ${var.jfrog_platform_chart_version} --namespace ${var.namespace} --create-namespace -f ${path.module}/jfrog-values.yaml -f ${path.module}/artifactory-license.yaml -f ${path.module}/jfrog-artifactory-${var.sizing}-adjusted.yaml -f ${path.module}/jfrog-custom.yaml --timeout 600s"
 }

--- a/7.jfrog-platform-aws-install/rds.tf
+++ b/7.jfrog-platform-aws-install/rds.tf
@@ -10,14 +10,28 @@ resource "aws_db_subnet_group" "jfrog_subnet_group" {
 }
 
 resource "aws_db_instance" "artifactory_db" {
-  identifier             = "artifactory-db"
-  engine                 = "postgres"
-  engine_version         = "16.4" # Specify the desired version
-  instance_class         = "db.m7g.large" # Change as needed based on expected load
+  identifier       = "artifactory-db"
+  engine           = "postgres"
+  engine_version   = var.rds_postgres_version
+  # Set the instance class based on the sizing variable
+  instance_class = (
+    var.sizing == "medium"  ? var.artifactory_rds_size_medium :
+    var.sizing == "large"   ? var.artifactory_rds_size_large :
+    var.sizing == "xlarge"  ? var.artifactory_rds_size_xlarge :
+    var.sizing == "2xlarge" ? var.artifactory_rds_size_2xlarge :
+    var.artifactory_rds_size_default
+  )
 
-  storage_type           = "gp3"       # Using gp3 for storage type
-  allocated_storage      = 50          # Set desired storage size in GB
-  max_allocated_storage  = 100         # Set maximum size for storage autoscaling (optional)
+  storage_type      = "gp3"
+  allocated_storage = (
+    var.sizing == "medium"  ? "250" :
+    var.sizing == "large"   ? "500" :
+    var.sizing == "xlarge"  ? "1000" :
+    var.sizing == "2xlarge" ? "1500" :
+    "100"
+  )
+
+  max_allocated_storage  = 2000          # Set maximum size for storage autoscaling (optional)
   storage_encrypted      = true
 
   db_name                = var.artifactory_db_name
@@ -34,14 +48,28 @@ resource "aws_db_instance" "artifactory_db" {
 }
 
 resource "aws_db_instance" "xray_db" {
-  identifier             = "xray-db"
-  engine                 = "postgres"
-  engine_version         = "16.4" # Specify the desired version
-  instance_class         = "db.m7g.large" # Change as needed based on expected load
+  identifier       = "xray-db"
+  engine           = "postgres"
+  engine_version   = var.rds_postgres_version
+  # Set the instance class based on the sizing variable
+  instance_class = (
+    var.sizing == "medium"  ? var.xray_rds_size_medium :
+    var.sizing == "large"   ? var.xray_rds_size_large :
+    var.sizing == "xlarge"  ? var.xray_rds_size_xlarge :
+    var.sizing == "2xlarge" ? var.xray_rds_size_2xlarge :
+    var.xray_rds_size_default
+  )
 
-  storage_type           = "gp3"       # Using gp3 for storage type
-  allocated_storage      = 50          # Set desired storage size in GB
-  max_allocated_storage  = 100         # Set maximum size for storage autoscaling (optional)
+  storage_type      = "gp3"
+  allocated_storage = (
+    var.sizing == "medium"  ? "250" :
+    var.sizing == "large"   ? "500" :
+    var.sizing == "xlarge"  ? "1000" :
+    var.sizing == "2xlarge" ? "1500" :
+    "100"
+  )
+
+  max_allocated_storage  = 2000          # Set maximum size for storage autoscaling (optional)
   storage_encrypted      = true
 
   db_name                = var.xray_db_name

--- a/7.jfrog-platform-aws-install/s3.tf
+++ b/7.jfrog-platform-aws-install/s3.tf
@@ -1,7 +1,7 @@
 # This file is used to create an S3 bucket for Artifactory to store binaries
 
 resource "aws_s3_bucket" "artifactory_binarystore" {
-  bucket = "artifactory-${var.region}-eldada-example"
+  bucket = "artifactory-${var.region}-${var.s3_bucket_name_suffix}"
 
   # WARNING: This will force the bucket to be destroyed even if it's not empty
   force_destroy = true

--- a/7.jfrog-platform-aws-install/variables.tf
+++ b/7.jfrog-platform-aws-install/variables.tf
@@ -21,6 +21,78 @@ variable "private_subnet_cidrs" {
   default = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
 }
 
+variable "rds_postgres_version" {
+  default     = "16.4"
+}
+
+variable "s3_bucket_name_suffix" {
+  default = "jfrog-demo"
+}
+
+variable "artifactory_rds_size_default" {
+  default = "db.m7g.2xlarge"
+}
+
+variable "artifactory_rds_size_medium" {
+  default = "db.m7g.4xlarge"
+}
+
+variable "artifactory_rds_size_large" {
+  default = "db.m7g.8xlarge"
+}
+
+variable "artifactory_rds_size_xlarge" {
+  default = "db.m7g.12xlarge"
+}
+
+variable "artifactory_rds_size_2xlarge" {
+  default = "db.m7g.16xlarge"
+}
+
+variable "xray_rds_size_default" {
+  default = "db.m7g.xlarge"
+}
+
+variable "xray_rds_size_medium" {
+  default = "db.m7g.2xlarge"
+}
+
+variable "xray_rds_size_large" {
+  default = "db.m7g.4xlarge"
+}
+
+variable "xray_rds_size_xlarge" {
+  default = "db.m7g.8xlarge"
+}
+
+variable "xray_rds_size_2xlarge" {
+  default = "db.m7g.12xlarge"
+}
+
+variable "artifactory_node_size_default" {
+  default = "m7g.2xlarge"
+}
+
+variable "artifactory_node_size_large" {
+  default = "m7g.4xlarge"
+}
+
+variable "xray_node_size_default" {
+  default = "c7g.2xlarge"
+}
+
+variable "xray_node_size_xlarge" {
+  default = "c7g.4xlarge"
+}
+
+variable "nginx_node_size_default" {
+  default = "c7g.xlarge"
+}
+
+variable "nginx_node_size_large" {
+  default = "c7g.2xlarge"
+}
+
 variable "artifactory_db_name" {
   description = "The database name"
   default     = "artifactory"
@@ -61,11 +133,30 @@ variable "namespace" {
   default = "jfrog"
 }
 
+variable "artifactory_chart_version" {
+  default = "107.98.9"
+}
+
+variable "xray_chart_version" {
+  default = "103.107.11"
+}
+
 variable "jfrog_platform_chart_version" {
-  default = "10.20.0"
+  default = "10.20.1"
 }
 
 variable "common_tag" {
   description = "The 'Group' tag to apply to all resources"
   default = "jfrog"
+}
+
+variable "sizing" {
+  type        = string
+  description = "The sizing templates for the infrastructure and Artifactory"
+  default     = "small"
+
+  validation {
+    condition     = contains(["small", "medium", "large", "xlarge", "2xlarge"], var.sizing)
+    error_message = "Invlid sizing set. Supported sizings are: 'small', 'medium', 'large', 'xlarge' or '2xlarge'"
+  }
 }


### PR DESCRIPTION
Added support sizing for the jfrog platform example. This closes the requirement of https://github.com/eldada/terraform-playground/issues/5.
