### PR TITLE
added env env_name var for segregating clusters and eds instances

### DIFF
--- a/6.artifactory-aws-install/README.md
+++ b/6.artifactory-aws-install/README.md
@@ -35,12 +35,12 @@ terraform init
 
 2. Plan the Terraform configuration by running the following command
 ```shell
-terraform plan -var 'sizing=small'
+terraform plan -var 'sizing=small' -var 'env_name=my-env'
 ```
 
 3. Apply the Terraform configuration by running the following command
 ```shell
-terraform apply -var 'sizing=small'
+terraform apply -var 'sizing=small' -var 'env_name=my-env'
 ```
 
 4. When you are done, you can destroy the resources by running the following command

--- a/6.artifactory-aws-install/artifactory.tf
+++ b/6.artifactory-aws-install/artifactory.tf
@@ -44,7 +44,7 @@ resource "local_file" "artifactory_values" {
       maxCacheSize: "${local.cache-fs-size}000000000"
       awsS3V3:
         region: "${var.region}"
-        bucketName: "artifactory-${var.region}-${var.s3_bucket_name_suffix}"
+        bucketName: "artifactory-${var.region}-${var.env_name}"
 
   database:
     url: "jdbc:postgresql://${aws_db_instance.artifactory_db.endpoint}/${var.db_name}?sslmode=require"

--- a/6.artifactory-aws-install/eks.tf
+++ b/6.artifactory-aws-install/eks.tf
@@ -1,7 +1,7 @@
 # This file is used to create an AWS EKS cluster and the managed node group(s)
 
 locals {
-    cluster_name = var.cluster_name
+    cluster_name = "${var.env_name}-eks-cluster"
 }
 
 resource "aws_security_group_rule" "allow_management_from_my_ip" {

--- a/6.artifactory-aws-install/eks.tf
+++ b/6.artifactory-aws-install/eks.tf
@@ -56,7 +56,7 @@ module "eks" {
             }
         }
         tags = {
-            Group = var.common_tag
+            Group = var.env_name
         }
     }
 
@@ -152,7 +152,7 @@ module "eks" {
     }
 
     tags = {
-        Group = var.common_tag
+        Group = var.env_name
     }
 }
 

--- a/6.artifactory-aws-install/outputs.tf
+++ b/6.artifactory-aws-install/outputs.tf
@@ -27,5 +27,5 @@ output "_05_setting_cluster_kubectl_context" {
 # Output the command to install Artifactory with Helm
 output "_06_artifactory_install_command" {
   description = "The Helm command to install Artifactory (after setting up kubectl context)"
-  value = "helm upgrade --install artifactory jfrog/artifactory --version ${var.artifactory_chart_version} --namespace ${var.namespace} --create-namespace -f ${path.module}/artifactory-values.yaml -f ${path.module}/artifactory-license.yaml -f ${path.module}/artifactory/sizing/artifactory-${var.sizing}.yaml -f ${path.module}/artifactory-custom.yaml --timeout 600s"
+  value = "helm upgrade --install artifactory jfrog/artifactory --version ${var.artifactory_chart_version} --namespace ${var.env_name} --create-namespace -f ${path.module}/artifactory-values.yaml -f ${path.module}/artifactory-license.yaml -f ${path.module}/artifactory/sizing/artifactory-${var.sizing}.yaml -f ${path.module}/artifactory-custom.yaml --timeout 600s"
 }

--- a/6.artifactory-aws-install/outputs.tf
+++ b/6.artifactory-aws-install/outputs.tf
@@ -15,7 +15,7 @@ output "_03_eks_cluster_name" {
 
 output "_04_resources_tag" {
   description = "The common tag applied on all resources"
-  value       = "Group: ${var.common_tag}"
+  value       = "Group: ${var.env_name}"
 }
 
 # Output the command to configure kubectl config to the newly created EKS cluster

--- a/6.artifactory-aws-install/rds.tf
+++ b/6.artifactory-aws-install/rds.tf
@@ -5,7 +5,7 @@ resource "aws_db_subnet_group" "artifactory_subnet_group" {
   subnet_ids = module.vpc.private_subnets
 
   tags = {
-    Group = var.common_tag
+    Group = var.env_name
   }
 }
 
@@ -44,7 +44,7 @@ resource "aws_db_instance" "artifactory_db" {
   skip_final_snapshot    = true
 
   tags = {
-    Group = var.common_tag
+    Group = var.env_name
   }
 }
 
@@ -66,6 +66,6 @@ resource "aws_security_group" "rds_sg" {
   }
 
   tags = {
-    Group = var.common_tag
+    Group = var.env_name
   }
 }

--- a/6.artifactory-aws-install/rds.tf
+++ b/6.artifactory-aws-install/rds.tf
@@ -1,7 +1,7 @@
 # This file creates an RDS instance for the Artifactory database
 
 resource "aws_db_subnet_group" "artifactory_subnet_group" {
-  name       = "artifactory-subnet-group"
+  name       = "artifactory-subnet-group-${var.env_name}"
   subnet_ids = module.vpc.private_subnets
 
   tags = {
@@ -10,7 +10,7 @@ resource "aws_db_subnet_group" "artifactory_subnet_group" {
 }
 
 resource "aws_db_instance" "artifactory_db" {
-  identifier       = "artifactory-db"
+  identifier       = "artifactory-db-${var.env_name}"
   engine           = "postgres"
   engine_version   = var.rds_postgres_version
 

--- a/6.artifactory-aws-install/s3.tf
+++ b/6.artifactory-aws-install/s3.tf
@@ -7,7 +7,7 @@ resource "aws_s3_bucket" "artifactory_binarystore" {
   force_destroy = true
 
   tags = {
-    Group = var.common_tag
+    Group = var.env_name
   }
 
   lifecycle {

--- a/6.artifactory-aws-install/s3.tf
+++ b/6.artifactory-aws-install/s3.tf
@@ -1,7 +1,7 @@
 # This file is used to create an S3 bucket for Artifactory to store binaries
 
 resource "aws_s3_bucket" "artifactory_binarystore" {
-  bucket = "artifactory-${var.region}-${var.s3_bucket_name_suffix}"
+  bucket = "artifactory-${var.region}-${var.env_name}"
 
   # WARNING: This will force the bucket to be destroyed even if it's not empty
   force_destroy = true

--- a/6.artifactory-aws-install/variables.tf
+++ b/6.artifactory-aws-install/variables.tf
@@ -148,11 +148,6 @@ variable "deploy_metrics_server" {
   default = true
 }
 
-variable "common_tag" {
-  description = "The 'Group' tag to apply to all resources"
-  default = var.env_name
-}
-
 variable "sizing" {
   type        = string
   description = "The sizing templates for the infrastructure and Artifactory"

--- a/6.artifactory-aws-install/variables.tf
+++ b/6.artifactory-aws-install/variables.tf
@@ -40,12 +40,8 @@ variable "db_password" {
   default     = "Password321"
 }
 
-variable "cluster_name" {
-  default = "jfrog-eks-cluster"
-}
-
-variable "s3_bucket_name_suffix" {
-  default = "jfrog-demo"
+variable "env_name" {
+  default = "jfrog"
 }
 
 variable "artifactory_rds_size_default" {

--- a/6.artifactory-aws-install/variables.tf
+++ b/6.artifactory-aws-install/variables.tf
@@ -137,7 +137,7 @@ variable "extra_node_size" {
 }
 
 variable "namespace" {
-  default = "jfrog"
+  default = var.env_name
 }
 
 variable "jfrog_charts_repository" {
@@ -154,7 +154,7 @@ variable "deploy_metrics_server" {
 
 variable "common_tag" {
   description = "The 'Group' tag to apply to all resources"
-  default = "jfrog"
+  default = var.env_name
 }
 
 variable "sizing" {

--- a/6.artifactory-aws-install/variables.tf
+++ b/6.artifactory-aws-install/variables.tf
@@ -136,10 +136,6 @@ variable "extra_node_size" {
   default = "c7g.xlarge"
 }
 
-variable "namespace" {
-  default = var.env_name
-}
-
 variable "jfrog_charts_repository" {
   default = "https://charts.jfrog.io"
 }

--- a/6.artifactory-aws-install/vpc.tf
+++ b/6.artifactory-aws-install/vpc.tf
@@ -31,6 +31,6 @@ module "vpc" {
     }
 
     tags = {
-        Group = var.common_tag
+        Group = var.env_name
     }
 }


### PR DESCRIPTION
## Proposed changes
- introduced new var - `env_name`
- removed the variable `s3_bucket_name_suffix`
- used the new var to compose the cluster name and s3 bucket name
- used the new var to compose rds instance and subnet groups